### PR TITLE
test: restore console.log in reporter tests

### DIFF
--- a/test/utils/reporter.test.ts
+++ b/test/utils/reporter.test.ts
@@ -6,8 +6,10 @@ import type { Result } from 'axe-core';
 describe('reporter', () => {
   let consoleOutput: string[] = [];
   const mockLog = vi.fn((...args: any[]) => consoleOutput.push(args.join(' ')));
-  
+  let originalLog: typeof console.log;
+
   beforeAll(() => {
+    originalLog = console.log;
     console.log = mockLog;
     chalk.level = 0; // Disable colors for testing
   });
@@ -18,7 +20,7 @@ describe('reporter', () => {
   });
 
   afterAll(() => {
-    console.log = console.log; // Restore original console.log
+    console.log = originalLog; // Restore original console.log
   });
 
   it('should report no violations correctly', async () => {


### PR DESCRIPTION
## Summary
- capture original `console.log` before mocking in reporter tests
- restore `console.log` after tests to prevent lingering mocks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a59da9252483319ae27dcc8bef5629

## Summary by Sourcery

Tests:
- Capture original console.log before mocking and restore it after tests in reporter.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test setup for log capture validation to ensure consistent behavior across test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->