### PR TITLE
Handle missing HTML snippets in reporter

### DIFF
--- a/src/utils/reporter.ts
+++ b/src/utils/reporter.ts
@@ -126,7 +126,10 @@ function enhanceFailureSummary(summary: string, violation: Result): string {
   return summary;
 }
 
-function cleanHtmlString(html: string): string {
+function cleanHtmlString(html?: string): string {
+  if (!html) {
+    return 'Unknown element';
+  }
   return html
     .replace(/\s+/g, ' ')  // Replace multiple spaces with single space
     .replace(/\s*([<>])\s*/g, '$1')  // Remove spaces around < and >

--- a/test/utils/reporter.test.ts
+++ b/test/utils/reporter.test.ts
@@ -6,6 +6,7 @@ import type { Result } from 'axe-core';
 describe('reporter', () => {
   let consoleOutput: string[] = [];
   const mockLog = vi.fn((...args: any[]) => consoleOutput.push(args.join(' ')));
+  const originalLog = console.log;
   
   beforeAll(() => {
     console.log = mockLog;
@@ -18,7 +19,7 @@ describe('reporter', () => {
   });
 
   afterAll(() => {
-    console.log = console.log; // Restore original console.log
+    console.log = originalLog; // Restore original console.log
   });
 
   it('should report no violations correctly', async () => {
@@ -61,8 +62,28 @@ describe('reporter', () => {
 
     await generateReport(results, { verbose: true });
     
-    expect(consoleOutput.some(output => 
+    expect(consoleOutput.some(output =>
       output.includes('Detailed Documentation')
     )).toBe(true);
+  });
+
+  it('should handle violations without html snippets', async () => {
+    const results = {
+      violations: [
+        {
+          ...mockViolation,
+          nodes: [
+            {
+              failureSummary: 'Fix any of the following: Element does not have an alt attribute'
+            }
+          ]
+        }
+      ]
+    };
+
+    await generateReport(results);
+
+    const outputString = consoleOutput.join('\n');
+    expect(outputString).toContain('Unknown element');
   });
 });


### PR DESCRIPTION
## Summary
- avoid crash when axe violation lacks `html` snippet by defaulting to "Unknown element"
- ensure reporter tests cover violations without html
- restore console.log after reporter tests

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a59242a88c8331a26ada80469eb28e

## Summary by Sourcery

Handle missing HTML snippets in the reporter by defaulting to “Unknown element,” add a test for violations without HTML, and fix console.log restoration in tests

New Features:
- Default to “Unknown element” when an axe violation lacks an HTML snippet

Bug Fixes:
- Restore original console.log correctly after reporter tests

Tests:
- Add test case to verify handling of violations without HTML snippets