### PR TITLE
test: remove duplicate mock reset

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -95,9 +95,6 @@ describe('index', () => {
     beforeEach(() => {
       // Reset mocks
       vi.clearAllMocks();
-      
-      // Reset mocks
-      vi.clearAllMocks();
     });
 
     it('should check static HTML content', async () => {


### PR DESCRIPTION
## Summary
- dedupe mock reset call in checkStaticHTML tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a59d9889248331bf0049927f3ebd34

## Summary by Sourcery

Tests:
- Remove redundant vi.clearAllMocks invocation in index tests